### PR TITLE
Revert nf-cmgg/configs back to nf-core/configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v2.1.1
 
 - Re-added the `genome` parameter to `nextflow.config` as it's needed by other configs.
+- Revert the default configs base to the nf-core configs in preparation of converting nf-cmgg/configs to a private repo
 
 ## v2.1.0 Jewel Jashari [2026-05-28]
 

--- a/main.nf
+++ b/main.nf
@@ -45,7 +45,7 @@ params {
     roi_sheet: Path?
 
     // The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.
-    outdir: Path
+    outdir: String
 
     // Email address for completion summary.
     email: String?

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,8 +25,8 @@ params {
     // Config options
     config_profile_name        = null
     config_profile_description = null
-    custom_config_version      = 'main'
-    custom_config_base         = "https://raw.githubusercontent.com/nf-cmgg/configs/${params.custom_config_version}"
+    custom_config_version      = 'master'
+    custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
     config_profile_contact     = null
     config_profile_url         = null
 
@@ -156,9 +156,6 @@ includeConfig params.custom_config_base && (!System.getenv('NXF_OFFLINE') || !pa
 
 // Load nf-cmgg/exomecnv custom profiles from different institutions.
 includeConfig params.custom_config_base && params.custom_config_base.contains('nf-cmgg') && (!System.getenv('NXF_OFFLINE') || !params.custom_config_base.startsWith('http')) ? "${params.custom_config_base}/pipeline/exomecnv.config" : "/dev/null"
-
-// Load igenomes.config if required
-includeConfig !params.igenomes_ignore as Boolean ? 'https://github.com/nf-cmgg/configs/raw/refs/heads/main/conf/genome/igenomes.config' : 'conf/igenomes_ignored.config'
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 // The JULIA depot path has been adjusted to a fixed path `/usr/local/share/julia` that needs to be used for packages in the container.


### PR DESCRIPTION
Revert back to nf-core/configs as the default. This will ensure that the pipeline will start working for everyone again and will prevent the pipeline from breaking when we make our configs private